### PR TITLE
Fix/various rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ module.exports = {
     'flowtype/use-flow-type': 1,
     'guard-for-in': 0,
     'import/prefer-default-export': 0,
+    'lines-between-class-members': 0,
     'new-cap': 0,
     'no-await-in-loop': 0,
     'no-only-tests/no-only-tests': 'error',

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = {
     'consistent-return': 0,
     'flowtype/define-flow-type': 1,
     'flowtype/require-parameter-type': 1,
+    'flowtype/require-valid-file-annotation': [ 2, 'always' ],
     'flowtype/space-after-type-colon': [ 1, 'always' ],
     'flowtype/space-before-type-colon': [ 1, 'never' ],
     'flowtype/type-id-match': [ 1, '^([A-Z][a-z0-9]+)+Type$' ],

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ module.exports = {
     'no-param-reassign': [ 1, { 'props': false } ],
     'no-restricted-syntax': 0,
     'no-unused-vars': [ 1, { 'args': 'none' } ],
+    'quote-props': ['error', 'as-needed', { keywords: false, unnecessary: true, numbers: true }],
   },
   globals: {
     describe: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-qare",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "The Qare ESLint",
   "main": "index.js",
   "author": "Qare team",


### PR DESCRIPTION
Add require flow-file annotation to ensure that Flow is used
Remove lines-between-class-members because it is harder to read
Changed quote-props rule to be compatible with flow
Bump version to 1.3.0 => API may not be compatible with this version